### PR TITLE
Feature/campus 124 optimisations

### DIFF
--- a/src/learning-material/csl/content-mapping/content.service.ts
+++ b/src/learning-material/csl/content-mapping/content.service.ts
@@ -55,7 +55,13 @@ export class CSLContentService {
 
   private extractCategoriesFromCsv = async () => {
     const contentRows = await this.fetchContentCsv();
-    return Array.from(new Set(contentRows.map((cr) => cr.category)));
+    return Array.from(
+      new Set(
+        contentRows.map((cr) =>
+          cr.category.replace(/ /g, '_').toLocaleLowerCase(),
+        ),
+      ),
+    );
   };
 
   async getAllCategories() {
@@ -76,7 +82,11 @@ export class CSLContentService {
   getCoursesForStrandAndCategory = async (strand: number, category: string) => {
     const contentRows = await this.fetchContentCsv();
     return contentRows
-      .filter((c) => c.category == category && c.strandID == strand)
+      .filter(
+        (c) =>
+          c.category.replace(/ /g, '_').toLocaleLowerCase() == category &&
+          c.strandID == strand,
+      )
       .map((c) => c.courseID);
   };
 }

--- a/src/learning-material/csl/csl.controller.ts
+++ b/src/learning-material/csl/csl.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { LearningMaterial } from '../models/LearningMaterial';
 import { CslService } from './csl.service';
@@ -16,6 +16,12 @@ export class CslController {
   async getLearningMaterialBySupplierAndId(
     @Param('materialId') materialId: string,
   ): Promise<LearningMaterial> {
-    return this.service.getCourse(materialId);
+    const course = this.service.getCourse(materialId);
+    if (!course) {
+      throw new NotFoundException(
+        `CSL course with ID ${materialId} was not found`,
+      );
+    }
+    return course;
   }
 }

--- a/src/learning-material/csl/csl.mapper.spec.ts
+++ b/src/learning-material/csl/csl.mapper.spec.ts
@@ -68,13 +68,31 @@ describe('CSLMapper', () => {
     const resp = await mapperUnderTest.mapCourseToLearningMaterial(
       sampleCourse,
     );
-    expect(resp.description).toEqual('description');
+    expect(resp.description[0].content[0]).toEqual('description');
+    expect(resp.description[0].label).toEqual('paragraph');
     expect(resp.shortDescription).toEqual('shortDescription');
-    expect(resp.outcomes).toEqual('learningOutcomes');
+    expect(resp.outcomes[0].content[0]).toEqual('learningOutcomes');
+    expect(resp.outcomes[0].label).toEqual('paragraph');
     expect(resp.id).toEqual('TEST01');
     expect(resp.title).toEqual('title');
     expect(resp.source).toEqual('csl');
     expect(resp.sourceHref).toEqual('http://test.com/courses/TEST01');
+  });
+
+  it('Should correctly render bullet-pointed content into a list', async () => {
+    const course = loadCourse();
+    course.description =
+      'paragraph1\n•\tbullet1\n•\tbullet2\nparagraph2\nparagraph3';
+    const resp = await mapperUnderTest.mapCourseToLearningMaterial(course);
+    const paragraphContent = resp.description;
+    expect(paragraphContent[0].label).toEqual('paragraph');
+    expect(paragraphContent[0].content[0]).toEqual('paragraph1');
+    expect(paragraphContent[1].label).toEqual('bullets');
+    expect(paragraphContent[1].content[0]).toEqual('bullet1');
+    expect(paragraphContent[1].label).toEqual('bullets');
+    expect(paragraphContent[1].content[1]).toEqual('bullet2');
+    expect(paragraphContent[2].label).toEqual('paragraph');
+    expect(paragraphContent[2].content[0]).toEqual('paragraph2');
   });
 
   it('Should correctly calculate the amount of minutes a course takes to complete', async () => {

--- a/src/learning-material/csl/csl.mapper.ts
+++ b/src/learning-material/csl/csl.mapper.ts
@@ -4,6 +4,7 @@ import { LearningMaterialSearchResult } from '../../search/models/Learningmateri
 import { CSLConfig } from './csl.config';
 import { Course } from './models/output/course.model';
 import { CSLSearchResult } from './models/output/search-results.model';
+import { labels, ParagraphContent } from '../models/ParagraphContent';
 
 @Injectable()
 export class CSLCourseMapper {
@@ -32,18 +33,54 @@ export class CSLCourseMapper {
     const totalDuration = Math.ceil(
       (await this.getTotalDuration(CSLMaterial)) / 60,
     );
+    const descFormatted = this.splitTextBody(CSLMaterial.description);
+    const outcomesFormatted = this.splitTextBody(CSLMaterial.learningOutcomes);
     return {
       source: 'csl',
       id: CSLMaterial.id,
-      description: CSLMaterial.description,
+      description: descFormatted,
       shortDescription: CSLMaterial.shortDescription,
-      outcomes: CSLMaterial.learningOutcomes,
+      outcomes: outcomesFormatted,
       title: CSLMaterial.title,
       duration: totalDuration,
       type: await this.getCourseType(CSLMaterial),
       sourceHref: `${this.config.frontendUrl}/courses/${CSLMaterial.id}`,
     };
   }
+
+  private splitTextBody = (text: string): ParagraphContent[] => {
+    const resultContent: ParagraphContent[] = [];
+
+    if (text) {
+      const lines = text
+        .split('\n')
+        .filter((line) => !!line)
+        .map((line) => line.trim());
+
+      let currentParagraph: ParagraphContent;
+      let inList = false;
+      for (let line of lines) {
+        if (line.startsWith('•')) {
+          if (!inList) {
+            inList = true;
+            currentParagraph = { label: labels.BULLETS, content: [] };
+          }
+          line = line.replace(/[•\t]/g, '');
+          currentParagraph.content.push(line);
+        } else {
+          if (inList) {
+            inList = false;
+            resultContent.push(currentParagraph);
+          }
+          if (line.length > 0) {
+            resultContent.push({ label: labels.PARAGRAPH, content: [line] });
+          }
+        }
+      }
+    }
+
+    return resultContent;
+  };
 
   private getTotalDuration = async (course: Course) => {
     return course.modules.reduce((sum, current) => sum + current.duration, 0);

--- a/src/learning-material/csl/csl.service.ts
+++ b/src/learning-material/csl/csl.service.ts
@@ -15,17 +15,28 @@ export class CslService {
   async getCourse(courseId: string) {
     const cacheKey = `csl:content:${courseId}`;
     return await this.cache.getObjectWithCallback(cacheKey, async () => {
-      const course = await this.clientService.getCourseWithId(courseId);
-      return await this.mapper.mapCourseToLearningMaterial(course);
+      const courses = await this.clientService.getCoursesWithIds([courseId]);
+      if (courses.length > 0) {
+        return await this.mapper.mapCourseToLearningMaterial(courses[0]);
+      } else {
+        return undefined;
+      }
     });
   }
 
   async getMultipleCourses(courseIds: string[]) {
     const courses = [];
+    const notFoundCourseIds = [];
     for (let i = 0; i < courseIds.length; i++) {
       const courseId = courseIds[i];
-      const course = await this.getCourse(courseId);
-      courses.push(course);
+      const course = await this.cache.getObject(`csl:content:${courseId}`);
+      course ? courses.push(course) : notFoundCourseIds.push(courseId);
+    }
+    if (notFoundCourseIds.length > 0) {
+      const notFoundCourses = await this.clientService.getCoursesWithIds(
+        notFoundCourseIds,
+      );
+      courses.push(...notFoundCourses);
     }
     return courses;
   }

--- a/src/learning-material/csl/csl.service.ts
+++ b/src/learning-material/csl/csl.service.ts
@@ -21,7 +21,13 @@ export class CslService {
   }
 
   async getMultipleCourses(courseIds: string[]) {
-    return Promise.all(courseIds.map(async (cId) => await this.getCourse(cId)));
+    const courses = [];
+    for (let i = 0; i < courseIds.length; i++) {
+      const courseId = courseIds[i];
+      const course = await this.getCourse(courseId);
+      courses.push(course);
+    }
+    return courses;
   }
 
   async searchForCourses(criteria: string, page: number) {

--- a/src/learning-material/csl/models/output/get-courses.model.ts
+++ b/src/learning-material/csl/models/output/get-courses.model.ts
@@ -1,0 +1,5 @@
+import { Course } from './course.model';
+
+export class GetCourses {
+  results: Course[];
+}

--- a/src/learning-material/models/LearningMaterial.ts
+++ b/src/learning-material/models/LearningMaterial.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { ParagraphContent } from './ParagraphContent';
 
 export class LearningMaterial {
   @ApiProperty()
@@ -10,8 +11,11 @@ export class LearningMaterial {
   @ApiProperty()
   title: string;
 
-  @ApiProperty()
-  description: string;
+  @ApiProperty({
+    description: 'Array of paragraphs that make up the description',
+    type: [ParagraphContent],
+  })
+  description: ParagraphContent[];
 
   @ApiProperty()
   duration: number;
@@ -22,8 +26,11 @@ export class LearningMaterial {
   @ApiProperty()
   shortDescription?: string;
 
-  @ApiProperty()
-  outcomes: string;
+  @ApiProperty({
+    description: 'Array of paragraphs that make up the learning outcomes',
+    type: [ParagraphContent],
+  })
+  outcomes: ParagraphContent[];
 
   @ApiProperty()
   sourceHref: string;

--- a/src/learning-material/models/ParagraphContent.ts
+++ b/src/learning-material/models/ParagraphContent.ts
@@ -1,0 +1,9 @@
+export enum labels {
+  PARAGRAPH = 'paragraph',
+  BULLETS = 'bullets',
+}
+
+export class ParagraphContent {
+  label: labels;
+  content: string[];
+}

--- a/src/strand/strand.service.spec.ts
+++ b/src/strand/strand.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CSLContentService } from '../learning-material/csl/content-mapping/content.service';
 import { CslService } from '../learning-material/csl/csl.service';
 import { LearningMaterial } from '../learning-material/models/LearningMaterial';
+import { ParagraphContent } from '../learning-material/models/ParagraphContent';
 import { StrandService } from './strand.service';
 
 const generateLearningMaterial = (
@@ -9,10 +10,10 @@ const generateLearningMaterial = (
   id: string,
 ): LearningMaterial => {
   return {
-    description: '',
+    description: [],
     duration: 0,
     id: id,
-    outcomes: '',
+    outcomes: [],
     source: '',
     sourceHref: '',
     title: title,

--- a/src/strand/validators/parse-category.pipe.spec.ts
+++ b/src/strand/validators/parse-category.pipe.spec.ts
@@ -25,16 +25,6 @@ describe('ParseCategoryPipe', () => {
     categoryPipe = moduleRef.get<ParseCategoryPipe>(ParseCategoryPipe);
   });
 
-  it('Should correctly transform an input category', async () => {
-    const res = await categoryPipe.transform('Category_1', null);
-    expect(res).toEqual('category_1');
-  });
-
-  it('Should correctly transform an input category with a capital', async () => {
-    const res = await categoryPipe.transform('Category 2', null);
-    expect(res).toEqual('category_2');
-  });
-
   it('Should throw a bad request exception when an invalid category is passed in', async () => {
     await expect(categoryPipe.transform('Category_3', null)).rejects.toEqual(
       new BadRequestException('invalid category supplied'),

--- a/src/strand/validators/parse-category.pipe.spec.ts
+++ b/src/strand/validators/parse-category.pipe.spec.ts
@@ -5,7 +5,7 @@ import { ParseCategoryPipe } from './parse-category.pipe';
 
 class MockCslContentService {
   async getAllCategories() {
-    return ['category 1', 'Category 2'];
+    return ['category_1', 'category_2'];
   }
 }
 
@@ -26,13 +26,13 @@ describe('ParseCategoryPipe', () => {
   });
 
   it('Should correctly transform an input category', async () => {
-    const res = await categoryPipe.transform('category_1', null);
-    expect(res).toEqual('category 1');
+    const res = await categoryPipe.transform('Category_1', null);
+    expect(res).toEqual('category_1');
   });
 
   it('Should correctly transform an input category with a capital', async () => {
-    const res = await categoryPipe.transform('Category_2', null);
-    expect(res).toEqual('Category 2');
+    const res = await categoryPipe.transform('Category 2', null);
+    expect(res).toEqual('category_2');
   });
 
   it('Should throw a bad request exception when an invalid category is passed in', async () => {

--- a/src/strand/validators/parse-category.pipe.ts
+++ b/src/strand/validators/parse-category.pipe.ts
@@ -12,7 +12,7 @@ export class ParseCategoryPipe implements PipeTransform {
   async transform(value: any, metadata: ArgumentMetadata) {
     const convertedValue: string = value;
     const categories = await this.cslContentService.getAllCategories();
-    if (!categories.includes(convertedValue)) {
+    if (!categories.includes(convertedValue.toLocaleLowerCase())) {
       throw new BadRequestException('invalid category supplied');
     }
     return convertedValue;

--- a/src/strand/validators/parse-category.pipe.ts
+++ b/src/strand/validators/parse-category.pipe.ts
@@ -10,8 +10,7 @@ import { CSLContentService } from '../../learning-material/csl/content-mapping/c
 export class ParseCategoryPipe implements PipeTransform {
   constructor(private readonly cslContentService: CSLContentService) {}
   async transform(value: any, metadata: ArgumentMetadata) {
-    let convertedValue: string = value;
-    convertedValue = convertedValue.replace(/_/g, ' ');
+    const convertedValue: string = value;
     const categories = await this.cslContentService.getAllCategories();
     if (!categories.includes(convertedValue)) {
       throw new BadRequestException('invalid category supplied');


### PR DESCRIPTION
- Courses are now fetched from CSL using the batch endpoint
- Paragraphs/bullets within CSL description/learning outcomes are separated into objects, making it simpler to render in the frontend